### PR TITLE
Make example as private and .init().

### DIFF
--- a/MoxtureTests/AnyFuncMockTests.swift
+++ b/MoxtureTests/AnyFuncMockTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class AnyFuncMockTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func testReset() {
         // given

--- a/MoxtureTests/FuncMockArgOptTests.swift
+++ b/MoxtureTests/FuncMockArgOptTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class FuncMockArgOptTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func test1Args() {
         // when

--- a/MoxtureTests/FuncMockArgOptThrowsTests.swift
+++ b/MoxtureTests/FuncMockArgOptThrowsTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class FuncMockArgOptThrowsTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func test1Args() throws {
         // when

--- a/MoxtureTests/FuncMockArgTests.swift
+++ b/MoxtureTests/FuncMockArgTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class FuncMockArgTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func test1Args() {
         // given

--- a/MoxtureTests/FuncMockArgThrowsTests.swift
+++ b/MoxtureTests/FuncMockArgThrowsTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class FuncMockArgThrowsTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func test1Args() throws {
         // given

--- a/MoxtureTests/FuncMockCommonTests.swift
+++ b/MoxtureTests/FuncMockCommonTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class FuncMockCommonTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func testReset() {
         // given

--- a/MoxtureTests/PropMockTests.swift
+++ b/MoxtureTests/PropMockTests.swift
@@ -25,17 +25,7 @@ import XCTest
 
 final class PropMockTests: XCTestCase {
 
-    fileprivate var example: ExampleMock!
-
-    override func setUp() {
-        super.setUp()
-        example = .init()
-    }
-
-    override func tearDown() {
-        example = nil
-        super.tearDown()
-    }
+    private var example: ExampleMock = .init()
 
     func testGetter() {
         // given


### PR DESCRIPTION
* As XCTestCase source code (https://github.com/apple/swift-corelibs-xctest/blob/02aa0cfbefb253dcc6250a3a0d4f3928204da534/Sources/XCTest/Private/XCTestCaseSuite.swift)

```
    init(testCaseEntry: XCTestCaseEntry) {
        let testCaseClass = testCaseEntry.testCaseClass
        self.testCaseClass = testCaseClass
        super.init(name: String(describing: testCaseClass))

        for (testName, testClosure) in testCaseEntry.allTests {
            let testCase = testCaseClass.init(name: testName, testClosure: testClosure)
            addTest(testCase)
        }
    }
```

Every test case is isolated, so you don't need to set example(SUT) be nil at tearDown(), be init() in SetUp().


* private access level will be great?