### PR TITLE
Replace structure to class to avoid copying on mutate

### DIFF
--- a/Moxture/AnyFuncMock.swift
+++ b/Moxture/AnyFuncMock.swift
@@ -20,7 +20,7 @@
 // SOFTWARE.
 //
 
-public struct AnyFuncMock {
+public final class AnyFuncMock {
 
     public var returns: Any?
 
@@ -41,24 +41,24 @@ public struct AnyFuncMock {
     public init() { }
 
     @discardableResult
-    public mutating func call(_ args: Any) -> Any? {
+    public func call(_ args: Any) -> Any? {
         calls.append(args)
         onCall?(args)
         return returns
     }
 
     @discardableResult
-    public mutating func callThrows(_ args: Any) throws -> Any? {
+    public func callThrows(_ args: Any) throws -> Any? {
         let result: Any? = call(args)
         if let error = self.throws { throw error }
         return result
     }
 
-    public mutating func onCall(_ closure: @escaping (Any) -> Void) {
+    public func onCall(_ closure: @escaping (Any) -> Void) {
         onCall = closure
     }
 
-    public mutating func reset() {
+    public func reset() {
         returns = nil
         `throws` = nil
         calls = []
@@ -67,6 +67,6 @@ public struct AnyFuncMock {
 }
 
 public extension AnyFuncMock {
-    mutating func call() -> Any? { call(()) }
-    mutating func callThrows() throws -> Any? { try callThrows(()) }
+    func call() -> Any? { call(()) }
+    func callThrows() throws -> Any? { try callThrows(()) }
 }

--- a/Moxture/FuncMock+Fixturable.swift
+++ b/Moxture/FuncMock+Fixturable.swift
@@ -24,13 +24,13 @@
 // the mock returns `.fixture` as a default value.
 
 public extension FuncMock where Return: Fixturable {
-    mutating func call(_ args: Args) -> Return {
+    func call(_ args: Args) -> Return {
         call(args) ?? .fixture
     }
 }
 
 public extension FuncMock where Args == Void, Return: Fixturable {
-    mutating func call() -> Return {
+    func call() -> Return {
         call(()) ?? .fixture
     }
 }

--- a/Moxture/FuncMock+Init.swift
+++ b/Moxture/FuncMock+Init.swift
@@ -25,185 +25,185 @@
 // as `FuncMock(self.function)` without explicitly specifying generic types.
 
 public extension FuncMock {
-    init(_ f: () -> Return) where Args == Void {
+    convenience init(_ f: () -> Return) where Args == Void {
         self.init()
     }
 
-    init(_ f: (Args) -> Return) {
+    convenience init(_ f: (Args) -> Return) {
         self.init()
     }
 
-    init<A0, A1>(_ f: (A0, A1) -> Return) where Args == (A0, A1) {
+    convenience init<A0, A1>(_ f: (A0, A1) -> Return) where Args == (A0, A1) {
         self.init()
     }
 
-    init<A0, A1, A2>(_ f: (A0, A1, A2) -> Return) where Args == (A0, A1, A2) {
+    convenience init<A0, A1, A2>(_ f: (A0, A1, A2) -> Return) where Args == (A0, A1, A2) {
         self.init()
     }
 
-    init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) -> Return) where Args == (A0, A1, A2, A3) {
+    convenience init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) -> Return) where Args == (A0, A1, A2, A3) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) -> Return) where Args == (A0, A1, A2, A3, A4) {
+    convenience init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) -> Return) where Args == (A0, A1, A2, A3, A4) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) -> Return) where Args == (A0, A1, A2, A3, A4, A5) {
+    convenience init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) -> Return) where Args == (A0, A1, A2, A3, A4, A5) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
-        self.init()
-    }
-}
-
-public extension FuncMock {
-    init(_ f: () throws -> Return) where Args == Void {
-        self.init()
-    }
-
-    init(_ f: (Args) throws -> Return) {
-        self.init()
-    }
-
-    init<A0, A1>(_ f: (A0, A1) throws -> Return) where Args == (A0, A1) {
-        self.init()
-    }
-
-    init<A0, A1, A2>(_ f: (A0, A1, A2) throws -> Return) where Args == (A0, A1, A2) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) throws -> Return) where Args == (A0, A1, A2, A3) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) throws -> Return) where Args == (A0, A1, A2, A3, A4) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
-        self.init()
-    }
-
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
         self.init()
     }
 }
 
 public extension FuncMock {
-    init(_ f: () -> Return?) where Args == Void {
+    convenience init(_ f: () throws -> Return) where Args == Void {
         self.init()
     }
 
-    init(_ f: (Args) -> Return?) {
+    convenience init(_ f: (Args) throws -> Return) {
         self.init()
     }
 
-    init<A0, A1>(_ f: (A0, A1) -> Return?) where Args == (A0, A1) {
+    convenience init<A0, A1>(_ f: (A0, A1) throws -> Return) where Args == (A0, A1) {
         self.init()
     }
 
-    init<A0, A1, A2>(_ f: (A0, A1, A2) -> Return?) where Args == (A0, A1, A2) {
+    convenience init<A0, A1, A2>(_ f: (A0, A1, A2) throws -> Return) where Args == (A0, A1, A2) {
         self.init()
     }
 
-    init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) -> Return?) where Args == (A0, A1, A2, A3) {
+    convenience init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) throws -> Return) where Args == (A0, A1, A2, A3) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) -> Return?) where Args == (A0, A1, A2, A3, A4) {
+    convenience init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) throws -> Return) where Args == (A0, A1, A2, A3, A4) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) -> Return?) where Args == (A0, A1, A2, A3, A4, A5) {
+    convenience init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) throws -> Return) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
         self.init()
     }
 }
 
 public extension FuncMock {
-    init(_ f: () throws -> Return?) where Args == Void {
+    convenience init(_ f: () -> Return?) where Args == Void {
         self.init()
     }
 
-    init(_ f: (Args) throws -> Return?) {
+    convenience init(_ f: (Args) -> Return?) {
         self.init()
     }
 
-    init<A0, A1>(_ f: (A0, A1) throws -> Return?) where Args == (A0, A1) {
+    convenience init<A0, A1>(_ f: (A0, A1) -> Return?) where Args == (A0, A1) {
         self.init()
     }
 
-    init<A0, A1, A2>(_ f: (A0, A1, A2) throws -> Return?) where Args == (A0, A1, A2) {
+    convenience init<A0, A1, A2>(_ f: (A0, A1, A2) -> Return?) where Args == (A0, A1, A2) {
         self.init()
     }
 
-    init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) throws -> Return?) where Args == (A0, A1, A2, A3) {
+    convenience init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) -> Return?) where Args == (A0, A1, A2, A3) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) throws -> Return?) where Args == (A0, A1, A2, A3, A4) {
+    convenience init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) -> Return?) where Args == (A0, A1, A2, A3, A4) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5) {
+    convenience init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) -> Return?) where Args == (A0, A1, A2, A3, A4, A5) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
         self.init()
     }
 
-    init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
+        self.init()
+    }
+}
+
+public extension FuncMock {
+    convenience init(_ f: () throws -> Return?) where Args == Void {
+        self.init()
+    }
+
+    convenience init(_ f: (Args) throws -> Return?) {
+        self.init()
+    }
+
+    convenience init<A0, A1>(_ f: (A0, A1) throws -> Return?) where Args == (A0, A1) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2>(_ f: (A0, A1, A2) throws -> Return?) where Args == (A0, A1, A2) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3>(_ f: (A0, A1, A2, A3) throws -> Return?) where Args == (A0, A1, A2, A3) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3, A4>(_ f: (A0, A1, A2, A3, A4) throws -> Return?) where Args == (A0, A1, A2, A3, A4) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3, A4, A5>(_ f: (A0, A1, A2, A3, A4, A5) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3, A4, A5, A6>(_ f: (A0, A1, A2, A3, A4, A5, A6) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8) {
+        self.init()
+    }
+
+    convenience init<A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(_ f: (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) throws -> Return?) where Args == (A0, A1, A2, A3, A4, A5, A6, A7, A8, A9) {
         self.init()
     }
 }

--- a/Moxture/FuncMock+Void.swift
+++ b/Moxture/FuncMock+Void.swift
@@ -23,31 +23,31 @@
 // Set of extensions to handle Void as arguments and as a return type
 
 public extension FuncMock where Args == Void {
-    mutating func call() -> Return { call(()) }
-    mutating func call() -> Return? { call(()) }
-    mutating func callThrows() throws -> Return { try callThrows(()) }
-    mutating func callThrows() throws -> Return? { try callThrows(()) }
+    func call() -> Return { call(()) }
+    func call() -> Return? { call(()) }
+    func callThrows() throws -> Return { try callThrows(()) }
+    func callThrows() throws -> Return? { try callThrows(()) }
 }
 
 public extension FuncMock where Return == Void {
-    mutating func call(_ args: Args) {
+    func call(_ args: Args) {
         calls.append(args)
         onCall?(args)
     }
 
-    mutating func callThrows(_ args: Args) throws {
+    func callThrows(_ args: Args) throws {
         call(args)
         if let error = self.throws { throw error }
     }
 }
 
 public extension FuncMock where Args == Void, Return == Void {
-    mutating func call() {
+    func call() {
         calls.append(())
         onCall?(())
     }
 
-    mutating func callThrows() throws {
+    func callThrows() throws {
         call()
         if let error = self.throws { throw error }
     }

--- a/Moxture/FuncMock.swift
+++ b/Moxture/FuncMock.swift
@@ -20,7 +20,7 @@
 // SOFTWARE.
 //
 
-public struct FuncMock<Args, Return> {
+public final class FuncMock<Args, Return> {
 
     public var returns: Return?
 
@@ -34,20 +34,20 @@ public struct FuncMock<Args, Return> {
 
     public var args: Args? { calls.first }
 
-    public mutating func call(_ args: Args) -> Return {
+    public func call(_ args: Args) -> Return {
         guard let returns = call(args) else {
             fatalError("returns is not set")
         }
         return returns
     }
 
-    public mutating func call(_ args: Args) -> Return? {
+    public func call(_ args: Args) -> Return? {
         calls.append(args)
         onCall?(args)
         return returns
     }
 
-    public mutating func callThrows(_ args: Args) throws -> Return {
+    public func callThrows(_ args: Args) throws -> Return {
         calls.append(args)
         onCall?(args)
         if let error = self.throws { throw error }
@@ -57,18 +57,18 @@ public struct FuncMock<Args, Return> {
         return returns
     }
 
-    public mutating func callThrows(_ args: Args) throws -> Return? {
+    public func callThrows(_ args: Args) throws -> Return? {
         calls.append(args)
         onCall?(args)
         if let error = self.throws { throw error }
         return returns
     }
 
-    public mutating func onCall(_ closure: @escaping (Args) -> Void) {
+    public func onCall(_ closure: @escaping (Args) -> Void) {
         onCall = closure
     }
 
-    public mutating func reset() {
+    public func reset() {
         returns = nil
         `throws` = nil
         calls = []

--- a/Moxture/PropMock+Fixturable.swift
+++ b/Moxture/PropMock+Fixturable.swift
@@ -24,7 +24,7 @@
 // then it is not required to set `returns` property and `.fixture` is automatically returned.
 
 public extension PropMock.Getter where Return: Fixturable {
-    mutating func call() -> Return {
+    func call() -> Return {
         call() ?? .fixture
     }
 }

--- a/Moxture/PropMock+Init.swift
+++ b/Moxture/PropMock+Init.swift
@@ -25,19 +25,19 @@
 // as `PropMock(\Type.property)` without explicitly specifying generic types.
 
 public extension PropMock {
-    init<T>(_ keyPath: ReferenceWritableKeyPath<T, Return>) {
+    convenience init<T>(_ keyPath: ReferenceWritableKeyPath<T, Return>) {
         self.init()
     }
 
-    init<T>(_ keyPath: KeyPath<T, Return>) {
+    convenience init<T>(_ keyPath: KeyPath<T, Return>) {
         self.init()
     }
 
-    init<T>(_ keyPath: ReferenceWritableKeyPath<T, Return?>) {
+    convenience init<T>(_ keyPath: ReferenceWritableKeyPath<T, Return?>) {
         self.init()
     }
 
-    init<T>(_ keyPath: KeyPath<T, Return?>) {
+    convenience init<T>(_ keyPath: KeyPath<T, Return?>) {
         self.init()
     }
 }

--- a/Moxture/PropMock.swift
+++ b/Moxture/PropMock.swift
@@ -20,12 +20,12 @@
 // SOFTWARE.
 //
 
-public struct PropMock<Return> {
+public final class PropMock<Return> {
 
     public var set = Setter<Return>()
     public var get = Getter<Return>()
 
-    public struct Setter<Return> {
+    public final class Setter<Return> {
 
         public var calls: [Return?] = []
 
@@ -35,27 +35,27 @@ public struct PropMock<Return> {
 
         public var args: Return? { calls.first ?? nil }
 
-        public mutating func call(_ arg: Return) {
+        public func call(_ arg: Return) {
             calls.append(arg)
             onCall?(arg)
         }
 
-        public mutating func call(_ arg: Return?) {
+        public func call(_ arg: Return?) {
             calls.append(arg)
             onCall?(arg)
         }
 
-        public mutating func onCall(_ closure: @escaping (Return?) -> Void) {
+        public func onCall(_ closure: @escaping (Return?) -> Void) {
             onCall = closure
         }
 
-        public mutating func reset() {
+        public func reset() {
             calls = []
             onCall = nil
         }
     }
 
-    public struct Getter<Return> {
+    public final class Getter<Return> {
 
         public var returns: Return?
 
@@ -65,24 +65,24 @@ public struct PropMock<Return> {
 
         public var called: Bool { !calls.isEmpty }
 
-        public mutating func call() -> Return {
+        public func call() -> Return {
             guard let returns = call() else {
                 fatalError("returns is not set")
             }
             return returns
         }
 
-        public mutating func call() -> Return? {
+        public func call() -> Return? {
             calls.append(())
             onCall?()
             return returns
         }
 
-        public mutating func onCall(_ closure: @escaping () -> Void) {
+        public func onCall(_ closure: @escaping () -> Void) {
             onCall = closure
         }
 
-        public mutating func reset() {
+        public func reset() {
             returns = nil
             calls = []
             onCall = nil
@@ -94,7 +94,7 @@ public struct PropMock<Return> {
         set { get.returns = newValue }
     }
 
-    public mutating func reset() {
+    public func reset() {
         get.reset()
         set.reset()
     }


### PR DESCRIPTION
## Description

This PR is to fix an issue related to copying `FuncMock`.

### Root cause
In some cases especially when passing to closures, we faced issues related to copying on mutate. Sometimes not all calls are written to `FuncMock`.

### Solution
Change all structure declaration to classes

### Impact
Apple recommends to use `struct` whenever it's possible for performance and safety reasons. Thus it may insignificantly impact the performance.