### PR TITLE
Add Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "Moxture",
+    platforms: [
+        .macOS(.v10_10),
+        .iOS(.v9),
+        .tvOS(.v9),
+        .watchOS(.v3)
+    ],
+    products: [
+        .library(
+            name: "Moxture",
+            targets: ["Moxture"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "Moxture",
+            dependencies: [],
+            path: "Moxture"),
+        .testTarget(
+            name: "MoxtureTests",
+            dependencies: ["Moxture"],
+            path: "MoxtureTests"),
+    ]
+)


### PR DESCRIPTION
## 🛠 Set Minimum Supported macOS Version to 10.10

The Swift Package Manager (SPM) has strict requirements for the minimum supported platform versions. When specifying platform compatibility in `Package.swift`, use the following:

```swift
platforms: [
    .macOS(.v10_10),
    .iOS(.v9),
    .tvOS(.v9),
    .watchOS(.v3)
]
```

### ❗️Why macOS 10.10?

* The lowest macOS version supported by SPM is **`.v10_10`**

* Using **`.v10_9` or earlier** will result in a compilation error such as:

  ```
  Reference to member 'v10_9' cannot be resolved without a contextual type
  ```

* This is because SwiftPM only defines `.v10_10` and newer for the `.macOS` enum. Older values are not available and will not compile.

* See [[SwiftPM PackageDescription documentation](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md)](https://github.com/apple/swift-package-manager/blob/main/Documentation/PackageDescription.md) for more details.

### ✅ Conclusion

To ensure compatibility and avoid build errors, the minimum supported macOS version must be set to **macOS 10.10 (`.v10_10`)**.